### PR TITLE
Support auto discovery for mirage and ember-data entities via import.meta.glob

### DIFF
--- a/ember-mirage/src/create-config.js
+++ b/ember-mirage/src/create-config.js
@@ -1,0 +1,69 @@
+import { createMirageModel, createMirageSerializer } from './ember-data';
+import { _utilsInflectorCamelize as camelize } from 'miragejs';
+
+async function getDefaultExports(modules) {
+  return Promise.all(
+    Object.entries(modules).map(([path, importFn]) =>
+      importFn().then((module) => ({ path, defaultExport: module.default })),
+    ),
+  );
+}
+
+function entityName(path) {
+  const filenameWithoutExt = path.split('/').pop().split('.')[0];
+  return camelize(filenameWithoutExt);
+}
+
+export default async function createConfig(
+  mirageImportMap = {},
+  emberDataConfig = {},
+) {
+  const serializers = await importEntities(mirageImportMap.serializers);
+
+  return {
+    factories: await importEntities(mirageImportMap.factories),
+    fixtures: await importEntities(mirageImportMap.fixtures),
+    models: {
+      ...importEmberDataModels(emberDataConfig),
+      ...(await importEntities(mirageImportMap.models)),
+    },
+    scenarios: await importEntities(mirageImportMap.scenarios),
+    serializers: {
+      ...importEmberDataSerializers(serializers, emberDataConfig),
+      ...serializers,
+    },
+    identityManagers: importEntities(mirageImportMap.identityManagers),
+  };
+}
+
+async function importEntities(importMap = {}) {
+  const modules = await getDefaultExports(importMap);
+
+  return modules.reduce((acc, { path, defaultExport }) => {
+    const configName = entityName(path);
+    acc[configName] = defaultExport;
+    return acc;
+  }, {});
+}
+
+function importEmberDataModels(emberDataConfig = {}) {
+  const { store, models = {} } = emberDataConfig;
+  return Object.keys(models).reduce((acc, path) => {
+    const configName = entityName(path);
+    acc[configName] = createMirageModel(store, configName);
+    return acc;
+  }, {});
+}
+
+function importEmberDataSerializers(mirageSerializers, emberDataConfig = {}) {
+  const { store, serializers = {} } = emberDataConfig;
+  return Object.keys(serializers).reduce((acc, path) => {
+    const configName = entityName(path);
+    acc[configName] = createMirageSerializer(
+      store,
+      mirageSerializers,
+      configName,
+    );
+    return acc;
+  }, {});
+}

--- a/ember-mirage/src/ember-data.js
+++ b/ember-mirage/src/ember-data.js
@@ -1,0 +1,87 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+import EmberDataSerializer from './ember-data-serializer';
+
+const MirageModelCache = {};
+const MirageSerializerCache = {};
+
+export function createMirageModel(store, modelName) {
+  if (MirageModelCache[modelName]) {
+    return MirageModelCache[modelName];
+  }
+
+  const model = store.modelFor(modelName);
+  const relationships = {};
+
+  model.eachRelationship((name, r) => {
+    if (r.kind === 'belongsTo') {
+      relationships[name] = belongsTo(r.type, r.options);
+    } else if (r.kind === 'hasMany') {
+      relationships[name] = hasMany(r.type, r.options);
+    }
+  });
+  const mirageModel = Model.extend(relationships);
+
+  MirageModelCache[modelName] = mirageModel;
+
+  return mirageModel;
+}
+
+export function createMirageSerializer(store, serializers, serializerName) {
+  if (MirageSerializerCache[serializerName]) {
+    return MirageSerializerCache[serializerName];
+  }
+
+  let mirageSerializer =
+    serializers[serializerName] ||
+    serializers.application ||
+    EmberDataSerializer;
+
+  let dsSerializer = store.serializerFor(serializerName);
+
+  let transforms;
+  let primaryKey = dsSerializer.primaryKey;
+  let attrs = dsSerializer.attrs;
+  if (primaryKey || attrs) {
+    if (attrs) {
+      let serializer = mirageSerializer.create
+        ? mirageSerializer.create()
+        : new mirageSerializer();
+
+      transforms = serializer.transforms || {};
+
+      Object.keys(attrs).forEach((key) => {
+        let transform = attrs[key];
+        let serializerTransform = serializer.transforms
+          ? serializer.transforms[key]
+          : {};
+        let resolvedTransform =
+          typeof attrs[key] === 'string'
+            ? {
+                key: attrs[key],
+              }
+            : {
+                key: attrs[key].key,
+              };
+
+        if (transform.serialize !== undefined) {
+          resolvedTransform.deserialize = transform.serialize;
+        }
+
+        if (transform.deserialize !== undefined) {
+          resolvedTransform.serialize = transform.deserialize;
+        }
+
+        transforms[key] = Object.assign(resolvedTransform, serializerTransform);
+      });
+    }
+
+    mirageSerializer = mirageSerializer.extend({
+      primaryKey,
+      transforms,
+    });
+  }
+
+  MirageSerializerCache[serializerName] = mirageSerializer;
+
+  return mirageSerializer;
+}

--- a/ember-mirage/src/start-mirage.js
+++ b/ember-mirage/src/start-mirage.js
@@ -2,7 +2,7 @@ import { pluralize, singularize } from 'active-inflector';
 
 import assert from './assert';
 
-export default function startMirage(
+export default async function startMirage(
   makeServer,
   { owner, env, ...otherOptions } = {},
 ) {
@@ -30,7 +30,7 @@ export default function startMirage(
     ...otherOptions,
   };
 
-  let server = makeServer(options);
+  let server = await makeServer(options);
 
   // Check to see if mirageLogging is on the URL. If so, enable logging on the server
   if (


### PR DESCRIPTION
Example:

```js
await discoverConfig(
  config,
  import.meta.glob(
    './{factories,fixtures,identity-managers,models,scenarios,serializers}/**/*.{js,ts}'
  ),
  import.meta.glob('../{models,serializers}/**/*.{js,ts}')
);
```


